### PR TITLE
added DisableClearBetweenFrames option

### DIFF
--- a/docs/sketch-configuration.md
+++ b/docs/sketch-configuration.md
@@ -40,6 +40,7 @@ There are other parameters not listed in the template. Here are the missing para
 | SketchOutlineColor | string | "#ffdb00" | sketch area outline color |
 | ControlBackgroundColor | string | "#1e1e1e" | control area background color |
 | ControlOutlineColor | string | "#ffdb00" | control area background color |
+| DisableClearBetweenFrames | bool | false | don't clear sketch area between frames |
 
 ## Control Parameters
 |Parameter| Type | Default | Description|


### PR DESCRIPTION
This adds an option to not clear the sketch area between every frame, which is the default.

To use the option add `"DisableClearBetweenFrames": true` to the configuration file.

To manually clear between one frame and the next, run `s.Clear()` in the `update` function.

This resolves issue #1 