### PR TITLE
added more screenshot options

### DIFF
--- a/colors.go
+++ b/colors.go
@@ -24,12 +24,18 @@ type ColorConfig struct {
 
 func (cc *ColorConfig) Set(hexString string, colorType ColorType, defaultString string) {
 	colorHexString := defaultString
+	var c color.Color
 	if hexString != "" {
 		colorHexString = hexString
 	}
-	c, err := colorful.Hex(colorHexString)
-	if err != nil {
-		panic(err)
+	if colorHexString == "" {
+		c = color.Transparent
+	} else {
+		d, err := colorful.Hex(colorHexString)
+		if err != nil {
+			panic(err)
+		}
+		c = d
 	}
 	switch colorType {
 	case BackgroundColorType:

--- a/examples/scale_rotate/sketch.json
+++ b/examples/scale_rotate/sketch.json
@@ -4,6 +4,7 @@
     "SketchWidth": 800,
     "SketchHeight": 800,
     "ControlWidth": 240,
+    "DisableClearBetweenFrames": true,
     "Controls": [
         {
             "Name": "N",

--- a/template/sketch.json
+++ b/template/sketch.json
@@ -17,5 +17,9 @@
             "Val": 0.9,
             "Incr": 0.01
         }
-    ]
+    ],
+    "SketchBackgroundColor": "#1e1e1e",
+    "SketchOutlineColor": "#ffdb00",
+    "ControlBackgroundColor": "#1e1e1e",
+    "ControlOutlineColor": "#ffdb00"
 }


### PR DESCRIPTION
added more screenshot options, mainly to enable saving the sketch area when `DisableEraseBetweenFrames` is used. By default the "s" key will take a screenshot, but saves the image via `gg`, which has the advantage of only saving pixels that have been drawn, i.e. PNG's with transparent backgrounds. The downside is that it has no memory of previous frames. There are now two addition screenshot options:
- "q" key: saves sketch area as PNG, all pixels. It makes sense to set `"SketchOutlineColor"=""` in the config file so that the outline is not saved.
- "Esc" key: uses ebiten's screenshot feature, that saves the entire window as a PNG with the `screenshot_` prefix.